### PR TITLE
Ps assign jobs

### DIFF
--- a/src/javascripts/components/staff/assignStaff.js
+++ b/src/javascripts/components/staff/assignStaff.js
@@ -29,7 +29,10 @@ const assignmentMenu = (employee, allJobs) => {
 
     if (employee.assignedTo === job) {
       submitFooter += `<div class="card-text text-secondary">(${allJobs[department][job].name} already assigned to ${employee.name})`;
+      utils.printToDom('#new-assignment', '');
+      $('#new-assignment-header').removeClass('text-info').addClass('text-secondary');
     } else {
+      $('#new-assignment-header').removeClass('text-secondary').addClass('text-info');
       if (allJobs[department][job].assigned) {
         let currentAssignees = '';
         for (let i = 0; i < allJobs[department][job].assignedTo.length; i += 1) {
@@ -61,11 +64,13 @@ const assignmentMenu = (employee, allJobs) => {
 };
 
 const assignStaff = (e) => {
+  e.preventDefault();
   const staffId = e.target.closest('.card').id;
   staffData.getStaffById(staffId)
     .then((employeeData) => {
       jobsData.getAllJobs()
         .then((allJobs) => {
+          $('.card-link').addClass('hide-assigned');
           const employee = employeeData.data;
           employee.id = staffId;
           const domString = `
@@ -73,9 +78,9 @@ const assignStaff = (e) => {
             <button type="button" class="close cancel-job-assignment" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           </div>
           <h5 class="card-title">${employee.name}</h5>
-          <h6 class="card-text">Current assignment:</h6>
+          <h6 class="card-text text-secondary">Current assignment:</h6>
           <p class="card-text text-secondary">${staffList.jobIcon(employee.assignmentCategory)} ${allJobs[employee.assignmentCategory][employee.assignedTo].name}</p>
-          <h6 class="card-text">New assignment:</h6>
+          <h6 class="card-text text-secondary" id="new-assignment-header">New assignment:</h6>
           <div id="new-assignment"></div>
           <div id="top-assignment-menu"></div>
           <div id="btm-assignment-menu"></div>

--- a/src/javascripts/components/staff/assignStaff.js
+++ b/src/javascripts/components/staff/assignStaff.js
@@ -4,7 +4,8 @@ import jobsData from '../../helpers/data/jobsData';
 import staffList from './staffList';
 
 const assignmentMenu = (employee, allJobs) => {
-  const populateJobMenu = () => {
+  const populateJobMenu = (e) => {
+    e.preventDefault();
     let jobOptions = '';
     const department = $('#assignjob-category').val();
     Object.keys(allJobs[department]).forEach((job) => {
@@ -20,7 +21,8 @@ const assignmentMenu = (employee, allJobs) => {
     $('#assignjob-assignment').prop('selectedIndex', -1);
   };
 
-  const getSelectedJob = () => {
+  const getSelectedJob = (e) => {
+    e.preventDefault();
     const department = $('#assignjob-category').val();
     const job = $('#assignjob-assignment').val();
     const display = `<p class="card-text text-info">${staffList.jobIcon(department)} ${allJobs[department][job].name}</p>`;
@@ -92,6 +94,7 @@ const assignStaff = (e) => {
 };
 
 const assignSelectedJob = (e) => {
+  e.preventDefault();
   const staffId = e.target.dataset.staffid;
   const department = $('#assignjob-category').val();
   const job = $('#assignjob-assignment').val();

--- a/src/javascripts/components/staff/editStaff.js
+++ b/src/javascripts/components/staff/editStaff.js
@@ -26,17 +26,24 @@ const editStaffDomStringBuilder = (collectionId, staffObj) => {
             <label for="editStaffName">Name:</label>
             <input type="text" class="form-control" id="editStaffName" value="${staffObj.name}">
         </div>
+
         <div class="form-group">
-            <label for="editStaffTitle">Title:</label>
-            <input type="text" class="form-control" name="editStaffTitle" value="${staffObj.title}">
+          <label for="editStaffTitle">Title</label>
+          <select name="editStaffTitle" id="editStaffTitle" class="form-control">
+            <option value="Dino Handler" ${staffObj.title === 'Dino Handler' ? ' selected' : ''}>Dino Handler</option>
+            <option value="Ride Attendant" ${staffObj.title === 'Ride Attendant' ? ' selected' : ''}>Ride Attendant</option>
+            <option value="Vendor Operator" ${staffObj.title === 'Vendor Operator' ? ' selected' : ''}>Vendor Operator</option>
+            <option value="" ${staffObj.title === '' ? ' selected' : ''}>(none)</option>
+          </select>
         </div>
+
         <div class="form-group">
             <label for="editStaffImgUrl">Image URL</label>
             <input type="text" class="form-control" name="editStaffImgUrl" value="${staffObj.imgUrl}">
         </div>
         <div class="form-group">
             <label for="editStaffActive">Currently Active?</label>
-            <input type="checkbox" class="form-control" name="isActive">
+            <input type="checkbox" name="isActive" checked>
         </div>
         <input type="hidden" class="form-control" name="collectionId" value="${collectionId}">
         <input type="hidden" class="form-control" name="assignedTo" value="${staffObj.assignedTo}">

--- a/src/javascripts/components/staff/staffList.js
+++ b/src/javascripts/components/staff/staffList.js
@@ -85,7 +85,7 @@ const staffCard = (employee) => {
   if (checkUser.checkUser()) {
     domString += `
           <div class="links card-text text-center">
-            ${employee.isActive ? '<a href="#" class="assignStaff mr-4 card-link"><i class="fas fa-calendar-plus"></i></a>' : ''}
+            ${employee.isActive ? '<a href="#" class="assignStaff mr-4 card-link"><i class="fas fa-id-card"></i></a>' : ''}
             <a href="#" class="editStaff mr-4 card-link"><i class="fas fa-pen"></i></a>
             <a href="#" class="deleteStaff ml-4 card-link"><i class="far fa-trash-alt"></i></a>
           </div>`;

--- a/src/javascripts/components/staff/staffList.js
+++ b/src/javascripts/components/staff/staffList.js
@@ -56,7 +56,12 @@ const addStaffForm = () => {
     </div>
     <div class="form-group">
       <label for="addStaffTitle">Staff Title</label>
-      <input type="text" class="form-control" name="addStaffTitle">
+      <select name="addStaffTitle" id="addStaffTitle" class="form-control">
+        <option value="Dino Handler">Dino Handler</option>
+        <option value="Ride Attendant">Ride Attendant</option>
+        <option value="Vendor Operator">Vendor Operator</option>
+        <option value="">(none)</option>
+      </select>
     </div>
     <div class="form-group">
       <label for="addStaffImgUrl">Staff Image URL</label>
@@ -147,6 +152,8 @@ const addStaff = (e) => {
     title: e.target.elements.addStaffTitle.value,
     imgUrl: e.target.elements.addStaffImgUrl.value,
     isActive: true,
+    assignedTo: '',
+    assignmentCategory: '',
   };
   staffData.addStaff(newStaff).then(() => {
     $('#addStaffModal').modal('hide');

--- a/src/javascripts/components/staff/staffList.js
+++ b/src/javascripts/components/staff/staffList.js
@@ -81,7 +81,7 @@ const staffCard = (employee) => {
       ${staffIcon(employee)}
       <div class="card-body">
         <h5 class="card-title">${employee.name}</h5>
-        <p class="card-text text-secondary">${employee.title}</p>`;
+        <p class="card-text text-secondary">${employee.title ? employee.title : 'Park Employee'}</p>`;
   if (employee.assignedTo === '') {
     domString += '<p class="card-text text-danger"><i class="fas fa-exclamation-triangle"></i> currently unassigned</p>';
   } else {

--- a/src/javascripts/components/staff/staffList.js
+++ b/src/javascripts/components/staff/staffList.js
@@ -76,7 +76,7 @@ const staffCard = (employee) => {
       ${staffIcon(employee)}
       <div class="card-body">
         <h5 class="card-title">${employee.name}</h5>
-        <p class="card-text">${employee.title}</p>`;
+        <p class="card-text text-secondary">${employee.title}</p>`;
   if (employee.assignedTo === '') {
     domString += '<p class="card-text text-danger"><i class="fas fa-exclamation-triangle"></i> currently unassigned</p>';
   } else {

--- a/src/javascripts/components/staff/staffList.scss
+++ b/src/javascripts/components/staff/staffList.scss
@@ -1,5 +1,6 @@
 .staff-card {
-  width: 18rem; 
+  width: 19rem; 
+  min-height: 350px;
 }
 
 .inactive {

--- a/src/javascripts/helpers/data/jobsData.js
+++ b/src/javascripts/helpers/data/jobsData.js
@@ -45,6 +45,28 @@ const getAllJobs = () => new Promise((resolve, reject) => {
     });
 });
 
-const assignNewJob = (staffId, department, job) => staffData.patchStaff(staffId, { assignedTo: job, assignmentCategory: department });
+const assignNewJob = (staffId, department, job) => new Promise((resolve, reject) => {
+  let title = '';
+  switch (department) {
+    case 'dinosaurs':
+      title = 'Dino Handler';
+      break;
+    case 'rides':
+      title = 'Ride Attendant';
+      break;
+    case 'vendors':
+      title = 'Vendor Operator';
+      break;
+    default:
+      title = '';
+  }
+  staffData.patchStaff(staffId, { assignedTo: job, assignmentCategory: department, title })
+    .then(() => {
+      resolve();
+    })
+    .catch((err) => reject(err));
+});
+
+// const assignNewJob = (staffId, department, job) => staffData.patchStaff(staffId, { assignedTo: job, assignmentCategory: department });
 
 export default { getAllJobs, assignNewJob };


### PR DESCRIPTION
When assigning a new job:
- employee's job title is automatically changed to reflect new position

When adding or editing a new employee:
- user must choose between job titles on dropdown menu

Staff cards:
- changed icon for assigning job
- display "Park Employee" if employee has no job title

When card switches to assign mode:
- staff card now prevented from changing height
- edit buttons on all other staff cards disappear
- page now prevented from scrolling to top

When card is in assign mode:
- 'New assignment' changes color when a new assignment is selected, but remains grey if no assignment or current assignment is selected